### PR TITLE
expose and call tags through a variable

### DIFF
--- a/release.mozilla.org/variables.tf
+++ b/release.mozilla.org/variables.tf
@@ -22,3 +22,13 @@ variable "description" {
 variable "build_container" {
   default = "jekyll/jekyll:latest"
 }
+
+variable "webops-tags" {
+  type = "map"
+  default = {
+    ServiceName      = "webops-release-mozilla-org"
+    TechnicalContact = "infra-webops@mozilla.com"
+    Environment      = "prod"
+    Purpose          = "website"
+  }
+}

--- a/tf_modules/s3_website/cloudfront.tf
+++ b/tf_modules/s3_website/cloudfront.tf
@@ -47,10 +47,5 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     cloudfront_default_certificate = true
   }
 
-  tags {
-    ServiceName      = "release.mozilla.org"
-    TechnicalContact = "infra-webops@mozilla.com"
-    Environment      = "stage"
-    Purpose          = "website"
-  }
+  tags = "${var.webops_tags}"
 }

--- a/tf_modules/s3_website/codebuild.tf
+++ b/tf_modules/s3_website/codebuild.tf
@@ -52,10 +52,5 @@ resource "aws_codebuild_project" "codebuild-project" {
     buildspec = "${var.buildspec}"
   }
 
-  tags {
-    ServiceName      = "release.mozilla.org"
-    TechnicalContact = "infra-webops@mozilla.com"
-    Environment      = "stage"
-    Purpose          = "website"
-  }
+  tags = "${var.webops_tags}"
 }

--- a/tf_modules/s3_website/s3.tf
+++ b/tf_modules/s3_website/s3.tf
@@ -13,12 +13,7 @@ resource "aws_s3_bucket" "prod_bucket" {
     target_prefix = "${var.service_name}-prod-logs/"
   }
 
-  tags {
-    ServiceName      = "release.mozilla.org"
-    TechnicalContact = "infra-webops@mozilla.com"
-    Environment      = "stage"
-    Purpose          = "website"
-  }
+  tags = "${var.webops_tags}"
 }
 
 # S3 bucket access log storage
@@ -26,11 +21,5 @@ resource "aws_s3_bucket" "prod_bucket" {
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "${var.service_name}-logs"
   acl    = "log-delivery-write"
-
-  tags {
-    ServiceName      = "release.mozilla.org"
-    TechnicalContact = "infra-webops@mozilla.com"
-    Environment      = "stage"
-    Purpose          = "website"
-  }
+  tags = "${var.webops_tags}"
 }

--- a/tf_modules/s3_website/variables.tf
+++ b/tf_modules/s3_website/variables.tf
@@ -3,6 +3,7 @@ variable "container" {}
 variable "source_repository" {}
 variable "service_name" {}
 variable "buildspec" {}
+variable "webops_tags" {}
 
 variable "website_domains" {
   type = "list"


### PR DESCRIPTION
I have debated this implementation. Initially I looked at setting a default `tags` map within the module itself but I was unable to find a good way to pull in the `ServiceName` tag based on the `service_name` variable passed into the module when we setup the site. We might be able to leverage Terraform `locals` later to introduce functionality like that:

https://www.terraform.io/docs/configuration/locals.html

I didn't want to setup the `locals` for the `ServiceName` in every module file responsible for resource creation so I decided not to use that.

This should be good for now! We'll just setup the tags in our top-level `variables.tf` for each site.